### PR TITLE
Fix nightly build issues

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -27,14 +27,11 @@ def vaultOverrides = [
 
 withNightlyPipeline(type, product, component) {
   env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"
-  env.TEST_URL = "http://civil-sdt-commissioning-aat.service.core-compute-aat.internal"
-  env.Rules = params.SecurityRules
-  env.execution_environment = "aat"
 
   overrideVaultEnvironments(vaultOverrides)
 
+  /*
   enableMutationTest()
-  enableSecurityScan()
 
   afterAlways('mutationTest') {
     publishHTML target: [
@@ -46,6 +43,7 @@ withNightlyPipeline(type, product, component) {
             reportName           : "Mutation Test Report"
     ]
   }
+  */
 
   afterAlways('fullFunctionalTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Removed enableSecurityScan() and associated configuration from Jenkinsfile_nightly.  The security scan expects a REST endpoint which sdt-commissioning doesn't have.
- Temporarily commented out mutation test configuration.  This will be addressed in SDT-118.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
