### PR TITLE
Reduce AppInsights health sampling rate

### DIFF
--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -2,5 +2,22 @@
   "connectionString": "${file:/mnt/secrets/civil-sdt/APPINSIGHTS_CONNECTION_STRING}",
   "role": {
     "name": "civil-sdt-gateway"
+  },
+  "preview": {
+    "sampling": {
+      "overrides": [
+        {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/health.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 1
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
As recommended by PlatOps, configured AppInsights to only sample 1% of health requests.  This will be enough to show any errors and will prevent logs from being swamped with them.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
