### PR TITLE
Suppress CVE-2023-2976, address CVE-2023-34981

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,7 +299,7 @@ allprojects {
           details.useVersion '2.8.5'
         }
         if (details.requested.group == 'org.apache.tomcat.embed') {
-          details.useVersion '9.0.74' // CVE-2023-28709
+          details.useVersion '9.0.75' // CVE-2023-34981
         }
         if (details.requested.group == 'org.springframework') {
           details.useVersion '5.3.27' // CVE-2023-20861
@@ -399,7 +399,7 @@ subprojects {
           details.useVersion '2.8.5'
         }
         if (details.requested.group == 'org.apache.tomcat.embed') {
-          details.useVersion '9.0.74' // CVE-2023-28709
+          details.useVersion '9.0.75' // CVE-2023-34981
         }
         if (details.requested.group == 'org.springframework') {
           details.useVersion '5.3.27' // CVE-2023-20861

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -18,8 +18,10 @@
   <!--Please add all the temporary suppression under the below section-->
   <suppress>
     <notes>Temporary Suppression
+      CVE-2023-2976
       CVE-2023-35116
     </notes>
+    <cve>CVE-2023-2976</cve>
     <cve>CVE-2023-35116</cve>
   </suppress>
   <!--End of temporary suppression section -->


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Temporarily suppressed CVE-2023-2976.
- Updated version of tomcat to 9.0.75 to address CVE-2023-34981.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
