### PR TITLE
Moved CVE-2023-35116 to false positives section

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,20 +7,22 @@
       CVE-2022-1471 - SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization, spring uses SafeConstructor which is the recommended workaround
       CVE-2022-40705 - see https://github.com/jeremylong/DependencyCheck/issues/5543
       CVE-2022-45688 - A stack overflow in the XML.toJSONObject component of hutool-json, hutool is not in the dependencies list when ./gradlew dependencies is run
+      CVE-2023-35116 - Not believed to be a valid vulnerability - see https://github.com/FasterXML/jackson-databind/issues/3972
     </notes>
     <cve>CVE-2016-3094</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2022-40705</cve>
     <cve>CVE-2022-45688</cve>
+    <cve>CVE-2023-35116</cve>
   </suppress>
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->
+  <!--
   <suppress>
     <notes>Temporary Suppression
-      CVE-2023-35116
     </notes>
-    <cve>CVE-2023-35116</cve>
   </suppress>
+  -->
   <!--End of temporary suppression section -->
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-143 (https://tools.hmcts.net/jira/browse/SDT-143)


### Change description ###
Moved CVE-2023-35116 to false positives section of suppressions.xml.  It's not believed to be a valid vulnerability and requests have been made to remove it from the NIST database.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
