### PR TITLE
Fix CVE-2023-41080

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+**/build/
 !gradle/wrapper/gradle-wrapper.jar
 *.class
 bin/main/application.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -289,23 +289,8 @@ allprojects {
   configurations.configureEach {
     resolutionStrategy {
       eachDependency { details ->
-        if (details.requested.group == 'com.github.ben-manes.caffeine' && details.requested.name == 'caffeine') {
-          details.useVersion '2.8.5'
-        }
         if (details.requested.group == 'org.apache.tomcat.embed') {
-          details.useVersion '9.0.75' // CVE-2023-34981
-        }
-        if (details.requested.group == 'org.springframework') {
-          details.useVersion '5.3.27' // CVE-2023-20861
-        }
-        if (details.requested.group == 'org.springframework.boot') {
-          details.useVersion '2.7.12' // CVE-2023-20883
-        }
-        if (details.requested.group == 'com.fasterxml.woodstox' && details.requested.name == 'woodstox-core') {
-          details.useVersion '6.4.0' // CVE-2022-40152
-        }
-        if (details.requested.group == 'org.eclipse.jetty') {
-          details.useVersion '9.4.51.v20230217' // CVE-2023-26049
+          details.useVersion '9.0.80' // CVE-2023-41080
         }
       }
     }
@@ -384,23 +369,8 @@ subprojects {
   configurations.configureEach {
     resolutionStrategy {
       eachDependency { details ->
-        if (details.requested.group == 'com.github.ben-manes.caffeine' && details.requested.name == 'caffeine') {
-          details.useVersion '2.8.5'
-        }
         if (details.requested.group == 'org.apache.tomcat.embed') {
-          details.useVersion '9.0.75' // CVE-2023-34981
-        }
-        if (details.requested.group == 'org.springframework') {
-          details.useVersion '5.3.27' // CVE-2023-20861
-        }
-        if (details.requested.group == 'org.springframework.boot') {
-          details.useVersion '2.7.12' // CVE-2023-20883
-        }
-        if (details.requested.group == 'com.fasterxml.woodstox' && details.requested.name == 'woodstox-core') {
-          details.useVersion '6.4.0' // CVE-2022-40152
-        }
-        if (details.requested.group == 'org.eclipse.jetty') {
-          details.useVersion '9.4.51.v20230217' // CVE-2023-26049
+          details.useVersion '9.0.80' // CVE-2023-41080
         }
       }
     }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -18,11 +18,11 @@
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->
+  <!--
   <suppress>
     <notes>Temporary Suppression
-      CVE-2023-41080
     </notes>
-    <cve>CVE-2023-41080</cve>
   </suppress>
+  -->
   <!--End of temporary suppression section -->
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Updated version of tomcat in build.gradle to 9.0.80 to fix CVE-2023-41080.
- Removed resolution strategies for com.github.ben-manes.caffeine, org.springframework, org.springframework.boot, com.fasterxml.woodstox and org.eclipse.jetty as they are no longer needed following update of org.springframework.boot plugin to 2.7.15 and other dependencies.
- Updated .gitignore to ignore contents of all build directories.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
