### PR TITLE
SDT-182 resolving CVE-2023-6378 and CVE-2023-6481

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,7 @@ ext {
 }
 
 ext['snakeyaml.version'] = '1.33'
+ext['logback.version'] = '1.2.13'
 
 allprojects {
   group 'uk.gov.hmcts.civil.sdt'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,10 +20,8 @@
   <!--Please add all the temporary suppression under the below section-->
   <suppress>
     <notes>Temporary Suppression
-      CVE-2023-6378
       CVE-2023-46604
     </notes>
-    <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-46604</cve>
   </suppress>
   <!--End of temporary suppression section -->

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,10 +20,8 @@
   <!--Please add all the temporary suppression under the below section-->
   <suppress>
     <notes>Temporary Suppression
-      CVE-2023-6481
       CVE-2023-46604
     </notes>
-    <cve>CVE-2023-6481</cve>
     <cve>CVE-2023-46604</cve>
   </suppress>
   <!--End of temporary suppression section -->


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SDT-182

### Change description ###

Removing CVE-2023-6378 suppression and setting the logback.version property to fix the CVE.
Also removed suppression for CVE-2023-6481 as it was also fixed by updating logback.version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
