### PR TITLE
Update tomcatVersion to v9.0.85

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ ext {
   cxfVersion = '3.6.2'
   sdtCommonVersion = '2.0.0'
   testcontainers = '1.17.5'
-  tomcatVersion = '9.0.84'
+  tomcatVersion = '9.0.85'
   limits = [
     'instruction': 99,
     'branch'     : 99,


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Updating tomcatVersion to 9.0.85 as Renovate won't create pull requests for sdt-commissioning and sdt-gateway because of the way the tomcat version is applied.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
