### PR TITLE
SDT-219: Stub new count stale requests method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ ext {
   log4JVersion = '2.23.1'
   lombokVersion = '1.18.24'
   cxfVersion = '3.6.3'
-  sdtCommonVersion = '2.1.1-SDT-219.0.1'
+  sdtCommonVersion = '3.0.0'
   testcontainers = '1.17.5'
   tomcatVersion = '9.0.89'
   limits = [

--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ ext {
   log4JVersion = '2.23.1'
   lombokVersion = '1.18.24'
   cxfVersion = '3.6.3'
-  sdtCommonVersion = '2.1.1'
+  sdtCommonVersion = '2.1.1-SDT-219.0.1'
   testcontainers = '1.17.5'
   tomcatVersion = '9.0.89'
   limits = [

--- a/producers-commissioning/src/main/java/uk/gov/moj/sdt/producers/comx/dao/MockIndividualRequestDao.java
+++ b/producers-commissioning/src/main/java/uk/gov/moj/sdt/producers/comx/dao/MockIndividualRequestDao.java
@@ -102,4 +102,10 @@ public class MockIndividualRequestDao extends MockGenericDao implements IIndivid
         // This method is implemented for the producers application only.
         return null;
     }
+
+    @Override
+    public long countStaleIndividualRequests(final int minimumAgeInMinutes) throws DataAccessException {
+        // This method is implemented for the producers application only.
+        return 0L;
+    }
 }

--- a/producers-commissioning/src/unit-test/java/uk/gov/moj/sdt/producers/comx/dao/MockIndividualRequestDaoTest.java
+++ b/producers-commissioning/src/unit-test/java/uk/gov/moj/sdt/producers/comx/dao/MockIndividualRequestDaoTest.java
@@ -8,6 +8,7 @@ import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -21,6 +22,7 @@ class MockIndividualRequestDaoTest extends AbstractSdtUnitTestBase {
     private static final String SDT_REF_ID = "SdtRefId";
 
     private static final int MAX_ATTEMPTS = 3;
+    private static final int MINIMUM_AGE_IN_MINUTES = 15;
 
     private MockIndividualRequestDao mockIndividualRequestDao;
 
@@ -65,5 +67,11 @@ class MockIndividualRequestDaoTest extends AbstractSdtUnitTestBase {
         List<IIndividualRequest> staleIndividualRequests =
             mockIndividualRequestDao.getStaleIndividualRequests(MAX_ATTEMPTS);
         assertNull(staleIndividualRequests, "List of stale IndividualRequests should be null");
+    }
+
+    @Test
+    void testCountStaleIndividualRequests() {
+        long requestCount = mockIndividualRequestDao.countStaleIndividualRequests(MINIMUM_AGE_IN_MINUTES);
+        assertEquals(0L, requestCount, "Count of stale IndividualRequests should be null");
     }
 }

--- a/producers-commissioning/src/unit-test/java/uk/gov/moj/sdt/producers/comx/dao/MockIndividualRequestDaoTest.java
+++ b/producers-commissioning/src/unit-test/java/uk/gov/moj/sdt/producers/comx/dao/MockIndividualRequestDaoTest.java
@@ -72,6 +72,6 @@ class MockIndividualRequestDaoTest extends AbstractSdtUnitTestBase {
     @Test
     void testCountStaleIndividualRequests() {
         long requestCount = mockIndividualRequestDao.countStaleIndividualRequests(MINIMUM_AGE_IN_MINUTES);
-        assertEquals(0L, requestCount, "Count of stale IndividualRequests should be null");
+        assertEquals(0L, requestCount, "Count of stale IndividualRequests should be 0");
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-219 (https://tools.hmcts.net/jira/browse/SDT-219)


### Change description ###
- Created a stub for new countStaleIndividualRequests() method on MockIndividualRequestDao.  This is needed due to change to IIndividualRequestsDao interface in SDT common.
- Added test for new method to MockIndividualRequestDaoTest.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
