### PR TITLE
SDT-226: Add ContextCleanupFilter config

### DIFF
--- a/producers-commissioning/src/main/java/uk/gov/moj/sdt/producers/comx/config/FilterConfig.java
+++ b/producers-commissioning/src/main/java/uk/gov/moj/sdt/producers/comx/config/FilterConfig.java
@@ -1,0 +1,21 @@
+package uk.gov.moj.sdt.producers.comx.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.moj.sdt.utils.web.filter.ContextCleanupFilter;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<ContextCleanupFilter> contextCleanupFilter() {
+        FilterRegistrationBean<ContextCleanupFilter> filterRegistrationBean = new FilterRegistrationBean<>();
+
+        filterRegistrationBean.setFilter(new ContextCleanupFilter());
+        filterRegistrationBean.addUrlPatterns("/producers-comx/service/*");
+        filterRegistrationBean.setOrder(1);
+
+        return filterRegistrationBean;
+    }
+}

--- a/producers-commissioning/src/unit-test/java/uk/gov/moj/sdt/producers/comx/config/FilterConfigTest.java
+++ b/producers-commissioning/src/unit-test/java/uk/gov/moj/sdt/producers/comx/config/FilterConfigTest.java
@@ -1,0 +1,42 @@
+package uk.gov.moj.sdt.producers.comx.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.utils.web.filter.ContextCleanupFilter;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class FilterConfigTest extends AbstractSdtUnitTestBase {
+
+    private FilterConfig filterConfig;
+
+    @Override
+    protected void setUpLocalTests() {
+        filterConfig = new FilterConfig();
+    }
+
+    @Test
+    void testContextCleanupFilter() {
+        FilterRegistrationBean<ContextCleanupFilter> filterRegistrationBean = filterConfig.contextCleanupFilter();
+
+        assertNotNull(filterRegistrationBean, "FilterRegistrationBean should not be null");
+
+        ContextCleanupFilter contextCleanupFilter = filterRegistrationBean.getFilter();
+        assertEquals("ContextCleanupFilter",
+                     contextCleanupFilter.getClass().getSimpleName(),
+                     "FilterRegistrationBean has unexpected filter class");
+
+        Collection<String> urlPatterns = filterRegistrationBean.getUrlPatterns();
+        assertNotNull(urlPatterns, "FilterRegistrationBean URL patterns should not be null");
+        assertEquals(1, urlPatterns.size(), "FilterRegistrationBean has unexpected number of URL patterns");
+        assertEquals("/producers-comx/service/*",
+                     urlPatterns.iterator().next(),
+                     "FilterRegistrationBean has unexpected URL pattern");
+
+        assertEquals(1, filterRegistrationBean.getOrder(), "FilterRegistrationBean has unexpected order");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-226 (https://tools.hmcts.net/jira/browse/SDT-226)


### Change description ###
- Added FilterConfig class to configure ContextCleanupFilter and register it.  The filter ensures that the SDT context is removed from thread local after each request has been processed.
- Added FilterConfigTest class.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
