### PR TITLE
SDT-227: Set timezone to Europe/London

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sdt/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/sdt/Application.java
@@ -6,16 +6,24 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
+
 // Disable auto configuration of data source as civil-sdt-commissioning doesn't use a database
 @SpringBootApplication(scanBasePackages = {"uk.gov.moj.sdt", "uk.gov.hmcts.reform.sdt"}, exclude = {
     DataSourceAutoConfiguration.class,
     DataSourceTransactionManagerAutoConfiguration.class,
     HibernateJpaAutoConfiguration.class
 })
-@SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
+@SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, it's not a utility class
 public class Application {
 
     public static void main(final String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/London"));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-227 (https://tools.hmcts.net/jira/browse/SDT-227)


### Change description ###
Added PostConstruct annotated method to Application.java to explicitly set the timezone to Europe/London.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
