### PR TITLE
SDT-261: Configure Renovate schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/automerge-minor"
-  ]
+  ],
+  "schedule": ["* 8-19 * * 1-5"],
+  "automergeSchedule": ["* 8-19 * * 1-5"],
+  "updateNotScheduled": false
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-261 (https://tools.hmcts.net/jira/browse/SDT-261)


### Change description ###
Configure Renovate to only create, update and merge dependency updates between 08:00 and 19:00, Monday to Friday.  This will prevent Renovate from attempting to make changes when Jenkins and the AAT environment aren't usually available.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
