### PR TITLE
SDT-213 Update Java to version 21

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
 ARG APP_INSIGHTS_AGENT_VERSION=3.7.7
-FROM hmctspublic.azurecr.io/base/java:17-distroless
+FROM hmctspublic.azurecr.io/base/java:21-distroless
 
 USER hmcts
 COPY lib/applicationinsights.json /opt/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
-<<<<<<< SDT-213
-ARG APP_INSIGHTS_AGENT_VERSION=3.7.7
-FROM hmctsprod.azurecr.io/base/java:21-distroless
-=======
 ARG APP_INSIGHTS_AGENT_VERSION=3.7.8
-FROM hmctsprod.azurecr.io/base/java:17-distroless
->>>>>>> master
+FROM hmctsprod.azurecr.io/base/java:21-distroless
 
 USER hmcts
 COPY lib/applicationinsights.json /opt/app

--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ ext {
   log4JVersion = '2.25.3'
   lombokVersion = '1.18.24'
   cxfVersion = '3.6.10'
-  sdtCommonVersion = '3.4.0-SDT-213.0.1'
+  sdtCommonVersion = '3.4.0-SDT-213.0.2'
   testcontainers = '1.17.5'
   tomcatVersion = '9.0.116'
   limits = [

--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ ext {
   log4JVersion = '2.25.4'
   lombokVersion = '1.18.24'
   cxfVersion = '3.6.10'
-  sdtCommonVersion = '3.4.0-SDT-213.0.2'
+  sdtCommonVersion = '4.0.0'
   testcontainers = '1.17.5'
   tomcatVersion = '9.0.117'
   limits = [

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ version = '0.0.1'
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 
@@ -213,7 +213,7 @@ ext {
   log4JVersion = '2.25.3'
   lombokVersion = '1.18.24'
   cxfVersion = '3.6.10'
-  sdtCommonVersion = '3.4.0'
+  sdtCommonVersion = '3.4.0-SDT-213.0.1'
   testcontainers = '1.17.5'
   tomcatVersion = '9.0.115'
   limits = [
@@ -228,6 +228,7 @@ ext {
 
 ext['snakeyaml.version'] = '1.33'
 ext['logback.version'] = '1.2.13'
+ext['byte-buddy.version'] = '1.17.7'
 
 allprojects {
   group 'uk.gov.hmcts.civil.sdt'
@@ -256,7 +257,7 @@ allprojects {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
 
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
-    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
+    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
     implementation 'com.sun.xml.bind:jaxb-core:4.0.6'
@@ -290,8 +291,7 @@ allprojects {
     }
 
     testImplementation 'com.github.hmcts:fortify-client:1.4.10:all'
-    testImplementation 'org.mockito:mockito-core:5.13.0'
-    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.21.0'
     testImplementation group: 'com.github.hmcts.civil-sdt-common', name: 'utils', version: sdtCommonVersion, classifier: 'test'
     testImplementation group: 'com.github.hmcts.civil-sdt-common', name: 'domain', version: sdtCommonVersion, classifier: 'test'
     testImplementation group: 'com.github.hmcts.civil-sdt-common', name: 'producers-api', version: sdtCommonVersion, classifier: 'test'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SDT-213
https://tools.hmcts.net/jira/browse/SDT-234


### Change description ###
Updated the Java version to 21 in the following files:-

- build.gradle
- ado_artifacts_build.yml
- ci.yml

Explicitly set byte-buddy to version 1.17.7
This is to allow mockito-core to be updated to version 5.21.0 as that version is required by Java 21.

Removed dependency for mockito-inline from build.gradle as this is no longer required.

Updated Java-logging to version 8.0.0 in build.gradle.

Set sdtCommonVersion to 3.4.0-SDT-213.0.1


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
