### PR TITLE
SDT-295 Updated tomcat to 9.0.117

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ ext {
   cxfVersion = '3.6.10'
   sdtCommonVersion = '3.4.0'
   testcontainers = '1.17.5'
-  tomcatVersion = '9.0.116'
+  tomcatVersion = '9.0.117'
   limits = [
     'instruction': 99,
     'branch'     : 99,

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -27,10 +27,6 @@
       CVE-2025-11143
       CVE-2025-15104 - This is believed to be a false positive. Further investigation required.
       CVE-2025-48924
-      CVE-2026-34483 
-      CVE-2026-34486
-      CVE-2026-34487
-      CVE-2026-34500
     </notes>
     <cve>CVE-2024-6763</cve>
     <cve>CVE-2024-8184</cve>
@@ -45,10 +41,6 @@
     <cve>CVE-2025-11143</cve>
     <cve>CVE-2025-15104</cve>
     <cve>CVE-2025-48924</cve>
-    <cve>CVE-2026-34483</cve>
-    <cve>CVE-2026-34486</cve>
-    <cve>CVE-2026-34487</cve>
-    <cve>CVE-2026-34500</cve>
   </suppress>
   <!--End of temporary suppression section -->
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SDT-295

### Change description ###
Updated tomcat to 9.0.117 and removed the following CVE from the suppression list:-
- CVE-2026-34483
- CVE-2026-34486
- CVE-2026-34487
- CVE-2026-34500

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
