### PR TITLE
SDT-365 Update jetty version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,7 @@ ext['snakeyaml.version'] = '1.33'
 ext['logback.version'] = '1.2.13'
 ext['byte-buddy.version'] = '1.17.7'
 ext['commons-lang3.version'] = '3.20.0'
+ext['jetty.version'] = '9.4.58.v20250814'
 
 allprojects {
   group 'uk.gov.hmcts.civil.sdt'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,14 +15,9 @@
   <suppress>
     <notes>Temporary Suppression
       CVE-2024-6763
-      CVE-2024-8184
-      CVE-2024-9823
-      CVE-2024-13009
-      CVE-2024-22201
       CVE-2024-22259
       CVE-2024-38808
       CVE-2024-38820
-      CVE-2025-5115
       CVE-2025-7962 - This is believed to be a false positive. Further investigation required.
       CVE-2025-11143
       CVE-2025-15104 - This is believed to be a false positive. Further investigation required.
@@ -87,14 +82,9 @@
       CVE-2026-66144
     </notes>
     <cve>CVE-2024-6763</cve>
-    <cve>CVE-2024-8184</cve>
-    <cve>CVE-2024-9823</cve>
-    <cve>CVE-2024-13009</cve>
-    <cve>CVE-2024-22201</cve>
     <cve>CVE-2024-22259</cve>
     <cve>CVE-2024-38808</cve>
     <cve>CVE-2024-38820</cve>
-    <cve>CVE-2025-5115</cve>
     <cve>CVE-2025-7962</cve>
     <cve>CVE-2025-11143</cve>
     <cve>CVE-2025-15104</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SDT-365

### Change description ###
Update jetty version to 9.4.58.v20250814

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
